### PR TITLE
chore: update go versions and goreleaser config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
 
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/go-e2e-tests.yaml
+++ b/.github/workflows/go-e2e-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: e2e tests
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Code Linting
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest", "windows-latest"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
 
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.21"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,4 @@
 ---
-before:
-  hooks:
-  - go mod tidy -compat=1.17
-
 builds:
   - id: demo-app
     goos: &goos-defs


### PR DESCRIPTION
Remove before hook to avoid go.sum changes during CI